### PR TITLE
Allow unix shebang

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,6 +6,7 @@ module.exports = function (src) {
         try {
             ast = parse(src, {
                 ecmaVersion: 6,
+                allowHashBang: true,
                 allowReturnOutsideFunction: true
             })
         }

--- a/test/hashbang.js
+++ b/test/hashbang.js
@@ -1,0 +1,13 @@
+var astw = require('../');
+var test = require('tape');
+
+test('hashbang', function (t) {
+    t.plan(2);
+    var numbers = [ 1, 2 ];
+    var walk = astw('#!/usr/bin/env node\n({"a":1,"b":2})');
+    walk(function (node) {
+        if (node.type === 'Literal' && typeof node.value === 'number') {
+            t.equal(node.value, numbers.shift());
+        }
+    });
+});


### PR DESCRIPTION
This patch passes `allowHashBang` option to `acorn` so that unix shebangs don't cause syntax errors.

```js

// ...
```