### PR TITLE
expose parsed ast

### DIFF
--- a/index.js
+++ b/index.js
@@ -12,9 +12,14 @@ module.exports = function (src, opts) {
         }
         catch (err) { ast = parse('(' + src + ')') }
     }
-    return function (cb) {
+
+    function walker (cb) {
         walk(ast, undefined, cb);
-    };
+    }
+
+    walker.ast = ast;
+
+    return walker;
 };
 
 function walk (node, parent, cb) {

--- a/readme.markdown
+++ b/readme.markdown
@@ -43,6 +43,10 @@ Walk the nodes in the ast with `cb(node)` where `node` is each element in the
 ast from [esprima](http://esprima.org/) but with an additional `.parent`
 reference to the parent node.
 
+## walk.ast
+
+Direct access to the parsed AST is still available at `walk.ast`.
+
 # install
 
 With [npm](https://npmjs.org) do:

--- a/test/ast.js
+++ b/test/ast.js
@@ -1,0 +1,8 @@
+var astw = require('../');
+var test = require('tape');
+
+test('ast', function (t) {
+    t.plan(1);
+    var walk = astw('var foo = 123;');
+    t.equal(walk.ast.type, "Program");
+});


### PR DESCRIPTION
If an app is already using `walk` it would be a shame to have to re-parse the src a second time just to get access to the parsed AST directly.

By simply exposing a reference on your API we can eliminate that inefficiency.